### PR TITLE
Change wine to wine64

### DIFF
--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -13,6 +13,6 @@ WINE_PREFIX="$SCR_PATH/prefix"
  
 export WINEPREFIX="$WINE_PREFIX"
 
-wine "$SCR_PATH/IllustratorCC17/IllustratorCC64.exe"
+wine64 "$SCR_PATH/IllustratorCC17/IllustratorCC64.exe"
 
 


### PR DESCRIPTION
There is a bug in wine when used in combination with Mesa 21.
X Error of failed request:  GLXBadFBConfig
https://bugs.winehq.org/show_bug.cgi?id=50859
Changing it to wine64 works.