### PR TITLE
add --no-check-certificate to wget

### DIFF
--- a/scripts/sharedFuncs.sh
+++ b/scripts/sharedFuncs.sh
@@ -207,7 +207,7 @@ function download_component() {
                 downrez=$?
             else
                 show_message "using wget to download $4"
-                wget "$3" -P "$CACHE_PATH"
+                wget --no-check-certificate "$3" -P "$CACHE_PATH"
                 downrez=$?
             fi
             if [ "$downrez" -eq 0 ];then


### PR DESCRIPTION
the instalation was failed due to the web that hosted illustrator has an expired certificate, producing an error.

added the wget --no-check-certificate and the installer was up and running again.