### PR TITLE
add -k and --no-check-certificate to curl and wget to ignore ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+--ssl cerificate issue fixed
 <div align="center" class="tip" markdown="1" style>
 
 ![ai screenshot](images/Screenshot-illustratorCC.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
---ssl cerificate issue fixed
+<h1>ssl cerificate issue fixed</h1>
 <div align="center" class="tip" markdown="1" style>
 
 ![ai screenshot](images/Screenshot-illustratorCC.png)

--- a/scripts/sharedFuncs.sh
+++ b/scripts/sharedFuncs.sh
@@ -203,11 +203,11 @@ function download_component() {
 
             elif [ "$curlpkg" == "true" ];then
                 show_message "using curl to download $4"
-                curl $3 -o $1
+                curl -k $3 -o $1
                 downrez=$?
             else
                 show_message "using wget to download $4"
-                wget "$3" -P "$CACHE_PATH"
+                wget --no-check-certificate "$3" -P "$CACHE_PATH"
                 downrez=$?
             fi
             if [ "$downrez" -eq 0 ];then


### PR DESCRIPTION
```
elif [ "$curlpkg" == "true" ];then
                show_message "using curl to download $4"
                curl -k $3 -o $1
                downrez=$?
            else
                show_message "using wget to download $4"
                wget --no-check-certificate "$3" -P "$CACHE_PATH"
                downrez=$?
 
```