### PR TITLE
⬆️ Updated file link address in illustratorSetup.sh

### DIFF
--- a/scripts/illustratorSetup.sh
+++ b/scripts/illustratorSetup.sh
@@ -65,7 +65,7 @@ function install_illustratorCC() {
     local filename="illustratorCC17.tgz"
     local filemd5="d470b541cef1339a66ea33a998801f83"
     # local filelink="http://127.0.0.1:4050/illustratorCC17.tgz"
-    local filelink="https://victor.poshtiban.io/p/gictor/illustratorCC/illustratorCC17.tgz"
+    local filelink="https://downloads.runebase.io/illustratorCC17.tgz"
     local filepath="$CACHE_PATH/$filename"
 
     download_component $filepath $filemd5 $filelink $filename


### PR DESCRIPTION
I changed broken download link: https://victor.poshtiban.io/p/gictor/illustratorCC/illustratorCC17.tgz to working one: https://downloads.runebase.io/illustratorCC17.tgz as per proposal here: https://github.com/Gictorbit/illustratorCClinux/issues/33#issuecomment-1288050791